### PR TITLE
Fix npm error on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"description": "QMK Firmware Builder",
 	"main": "index.js",
 	"scripts": {
-		"build": "NODE_PATH=./src node index.js",
-		"deploy": "NODE_PATH=./src NODE_ENV=production node deploy.js",
+		"build": "cross-env NODE_PATH=./src node index.js",
+		"deploy": "cross-env NODE_PATH=./src NODE_ENV=production node deploy.js",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"repository": {
@@ -37,5 +37,8 @@
 		"superagent": "^3.3.1",
 		"uglifyify": "^3.0.4",
 		"watchify": "^3.7.0"
+	},
+	"devDependencies": {
+		"cross-env": "^3.1.4"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "qmkbuilder",
-  "version": "1.0.0",
-  "description": "QMK Firmware Builder",
-  "main": "index.js",
-  "scripts": {
-    "build": "NODE_PATH=./src node index.js",
-    "deploy": "NODE_PATH=./src NODE_ENV=production node deploy.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ruiqimao/qmkbuilder.git"
-  },
-  "author": "ruiqimao",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/ruiqimao/qmkbuilder/issues"
-  },
-  "homepage": "https://github.com/ruiqimao/qmkbuilder#readme",
-  "dependencies": {
-    "babel": "^6.5.2",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babelify": "^7.3.0",
-    "body-parser": "^1.15.2",
-    "browserify": "^13.1.1",
-    "classnames": "^2.2.5",
-    "co": "^4.6.0",
-    "codemirror": "^5.22.0",
-    "crypto": "0.0.3",
-    "errorify": "^0.3.1",
-    "express": "^4.14.0",
-    "react": "^15.4.1",
-    "react-codemirror": "^0.3.0",
-    "react-dom": "^15.4.1",
-    "superagent": "^3.3.1",
-    "uglifyify": "^3.0.4",
-    "watchify": "^3.7.0"
-  }
+	"name": "qmkbuilder",
+	"version": "1.0.0",
+	"description": "QMK Firmware Builder",
+	"main": "index.js",
+	"scripts": {
+		"build": "NODE_PATH=./src node index.js",
+		"deploy": "NODE_PATH=./src NODE_ENV=production node deploy.js",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ruiqimao/qmkbuilder.git"
+	},
+	"author": "ruiqimao",
+	"license": "ISC",
+	"bugs": {
+		"url": "https://github.com/ruiqimao/qmkbuilder/issues"
+	},
+	"homepage": "https://github.com/ruiqimao/qmkbuilder#readme",
+	"dependencies": {
+		"babel": "^6.5.2",
+		"babel-preset-es2015": "^6.18.0",
+		"babel-preset-react": "^6.16.0",
+		"babelify": "^7.3.0",
+		"body-parser": "^1.15.2",
+		"browserify": "^13.1.1",
+		"classnames": "^2.2.5",
+		"co": "^4.6.0",
+		"codemirror": "^5.22.0",
+		"crypto": "0.0.3",
+		"errorify": "^0.3.1",
+		"express": "^4.14.0",
+		"react": "^15.4.1",
+		"react-codemirror": "^0.3.0",
+		"react-dom": "^15.4.1",
+		"superagent": "^3.3.1",
+		"uglifyify": "^3.0.4",
+		"watchify": "^3.7.0"
+	}
 }


### PR DESCRIPTION
Windows doesn't support setting environment variables via VAR=VAL, so we need to use the cross-env tool to set the variables in a cross-platform manner.

I also used WebStorm to reformat the package.json file, according to the rules it picked up from .editorconfig. If we're going to have a code style configuration checked into the repo, all code should be conformed to it.