### PR TITLE
Added a way to load a preset from a gist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,45 @@
 {
-	"name": "qmkbuilder",
-	"version": "1.0.0",
-	"description": "QMK Firmware Builder",
-	"main": "index.js",
-	"scripts": {
-		"build": "cross-env NODE_PATH=./src node index.js",
-		"deploy": "cross-env NODE_PATH=./src NODE_ENV=production node deploy.js",
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ruiqimao/qmkbuilder.git"
-	},
-	"author": "ruiqimao",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/ruiqimao/qmkbuilder/issues"
-	},
-	"homepage": "https://github.com/ruiqimao/qmkbuilder#readme",
-	"dependencies": {
-		"babel": "^6.5.2",
-		"babel-preset-es2015": "^6.18.0",
-		"babel-preset-react": "^6.16.0",
-		"babelify": "^7.3.0",
-		"body-parser": "^1.15.2",
-		"browserify": "^13.1.1",
-		"classnames": "^2.2.5",
-		"co": "^4.6.0",
-		"codemirror": "^5.22.0",
-		"crypto": "0.0.3",
-		"errorify": "^0.3.1",
-		"express": "^4.14.0",
-		"react": "^15.4.1",
-		"react-codemirror": "^0.3.0",
-		"react-dom": "^15.4.1",
-		"superagent": "^3.3.1",
-		"uglifyify": "^3.0.4",
-		"watchify": "^3.7.0"
-	},
-	"devDependencies": {
-		"cross-env": "^3.1.4"
-	}
+  "name": "qmkbuilder",
+  "version": "1.0.0",
+  "description": "QMK Firmware Builder",
+  "main": "index.js",
+  "scripts": {
+    "build": "cross-env NODE_PATH=./src node index.js",
+    "deploy": "cross-env NODE_PATH=./src NODE_ENV=production node deploy.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ruiqimao/qmkbuilder.git"
+  },
+  "author": "ruiqimao",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ruiqimao/qmkbuilder/issues"
+  },
+  "homepage": "https://github.com/ruiqimao/qmkbuilder#readme",
+  "dependencies": {
+    "babel": "^6.5.2",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babelify": "^7.3.0",
+    "body-parser": "^1.15.2",
+    "browserify": "^13.1.1",
+    "classnames": "^2.2.5",
+    "co": "^4.6.0",
+    "codemirror": "^5.22.0",
+    "crypto": "0.0.3",
+    "errorify": "^0.3.1",
+    "express": "^4.14.0",
+    "query-string": "^4.3.1",
+    "react": "^15.4.1",
+    "react-codemirror": "^0.3.0",
+    "react-dom": "^15.4.1",
+    "superagent": "^3.3.1",
+    "uglifyify": "^3.0.4",
+    "watchify": "^3.7.0"
+  },
+  "devDependencies": {
+    "cross-env": "^3.1.4"
+  }
 }


### PR DESCRIPTION
This is one possible solution to issue #8. This allows someone to share their QMK config with others easily just by uploading the .json file to a GitHub Gist. By appending the unique hash to the builder url (eg. "https://gist.github.com/username/hash" => "http://qmk.sized.io/?gist=hash"), the builder will automatically fetch and load that configuration.